### PR TITLE
Implement Assignment 2 navigation

### DIFF
--- a/lib/assignment2/details_screen.dart
+++ b/lib/assignment2/details_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class DetailsScreen extends StatefulWidget {
+  const DetailsScreen({super.key, required this.initialData});
+
+  final String initialData;
+
+  @override
+  State<DetailsScreen> createState() => _DetailsScreenState();
+}
+
+class _DetailsScreenState extends State<DetailsScreen> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialData);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _returnData() {
+    Navigator.pop(context, _controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Assignment 2 - Details')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'Edit data'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _returnData,
+              child: const Text('Return to Home'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/assignment2/home_screen.dart
+++ b/lib/assignment2/home_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'details_screen.dart';
+
+class Assignment2HomeScreen extends StatefulWidget {
+  const Assignment2HomeScreen({super.key});
+
+  @override
+  State<Assignment2HomeScreen> createState() => _Assignment2HomeScreenState();
+}
+
+class _Assignment2HomeScreenState extends State<Assignment2HomeScreen> {
+  final TextEditingController _controller = TextEditingController();
+  String _returnedData = '';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _openDetails() async {
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => DetailsScreen(initialData: _controller.text),
+      ),
+    );
+    if (result != null && result is String) {
+      setState(() => _returnedData = result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Assignment 2 - Home')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'Enter data to send'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _openDetails,
+              child: const Text('Go to Details'),
+            ),
+            const SizedBox(height: 16),
+            Text('Returned: ' + _returnedData),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'assignment2/home_screen.dart';
 
 void main() => runApp(const ProfileCardDemo());
 
@@ -35,6 +36,17 @@ class ProfileScreen extends StatelessWidget {
                 'Testing (K6) • SDLC | Agile | Jira | eCommerce & Media domains',
             imagePath: 'assets/images/profile_picture.png',
           ),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const Assignment2HomeScreen(),
+              ),
+            );
+          },
+          child: const Icon(Icons.navigate_next),
         ),
       );
 }


### PR DESCRIPTION
## Summary
- create `assignment2` directory with Home and Details screens
- pass data from home to details and back
- add navigation button in `ProfileScreen` to open Assignment 2

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e75aca7d08320ab807735951c89a7