### PR TITLE
Modularize assignments and add login screen

### DIFF
--- a/lib/assignment1/profile_card_screen.dart
+++ b/lib/assignment1/profile_card_screen.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+/// Screen displaying a profile card with an image, name and description.
+class ProfileCardScreen extends StatelessWidget {
+  const ProfileCardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: const Center(
+        child: ProfileCard(
+          name: 'Gaurav Kumar Jha',
+          description:
+              'QA Engineer • Software & Mobile Testing • API & Performance '
+              'Testing (K6) • SDLC | Agile | Jira | eCommerce & Media domains',
+          imagePath: 'assets/images/profile_picture.png',
+        ),
+      ),
+    );
+  }
+}
+
+/// Reusable card widget with internal "Follow" state.
+class ProfileCard extends StatefulWidget {
+  const ProfileCard({
+    super.key,
+    required this.name,
+    required this.description,
+    required this.imagePath,
+  });
+
+  final String name;
+  final String description;
+  final String imagePath;
+
+  @override
+  State<ProfileCard> createState() => _ProfileCardState();
+}
+
+class _ProfileCardState extends State<ProfileCard> {
+  bool _isFollowing = false;
+
+  void _toggleFollow() => setState(() => _isFollowing = !_isFollowing);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 3,
+      margin: const EdgeInsets.all(16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              radius: 48,
+              backgroundImage: AssetImage(widget.imagePath),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              widget.name,
+              style: Theme.of(context)
+                  .textTheme
+                  .titleLarge
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              widget.description,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 20),
+            FilledButton(
+              onPressed: _toggleFollow,
+              child: Text(_isFollowing ? 'Following' : 'Follow'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/assignment3/login_screen.dart
+++ b/lib/assignment3/login_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+/// Screen implementing a simple login form with validation.
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Login Successful')),
+      );
+    }
+  }
+
+  String? _validateEmail(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Email is required';
+    }
+    final emailRegex = RegExp(r'^\\S+@\\S+\\.\\S+$');
+    if (!emailRegex.hasMatch(value)) {
+      return 'Enter a valid email';
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Password is required';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                keyboardType: TextInputType.emailAddress,
+                validator: _validateEmail,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: _validatePassword,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Login'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,114 +1,69 @@
 import 'package:flutter/material.dart';
+import 'assignment1/profile_card_screen.dart';
 import 'assignment2/home_screen.dart';
+import 'assignment3/login_screen.dart';
 
-void main() => runApp(const ProfileCardDemo());
+void main() => runApp(const AssignmentsApp());
 
-/// Root widget that injects [ProfileScreen] and global theme.
-class ProfileCardDemo extends StatelessWidget {
-  const ProfileCardDemo({super.key});
+/// Root app that provides navigation to all assignments.
+class AssignmentsApp extends StatelessWidget {
+  const AssignmentsApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Profile Card Demo',
+      title: 'Flutter Assignments',
       theme: ThemeData(
         colorSchemeSeed: Colors.deepPurple,
         useMaterial3: true,
       ),
       debugShowCheckedModeBanner: false,
-      home: const ProfileScreen(),
+      home: const HomeScreen(),
     );
   }
 }
 
-/// Top-level screen; keeps the card centred.
-class ProfileScreen extends StatelessWidget {
-  const ProfileScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(title: const Text('Profile')),
-        body: const Center(
-          child: ProfileCard(
-            name: 'Gaurav Kumar Jha',
-            description:
-                'QA Engineer • Software & Mobile Testing • API & Performance '
-                'Testing (K6) • SDLC | Agile | Jira | eCommerce & Media domains',
-            imagePath: 'assets/images/profile_picture.png',
-          ),
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => const Assignment2HomeScreen(),
-              ),
-            );
-          },
-          child: const Icon(Icons.navigate_next),
-        ),
-      );
-}
-
-/// Reusable card widget with internal “Follow” state.
-class ProfileCard extends StatefulWidget {
-  const ProfileCard({
-    super.key,
-    required this.name,
-    required this.description,
-    required this.imagePath,
-  });
-
-  final String name;
-  final String description;
-  final String imagePath;
-
-  @override
-  State<ProfileCard> createState() => _ProfileCardState();
-}
-
-class _ProfileCardState extends State<ProfileCard> {
-  bool _isFollowing = false;
-
-  void _toggleFollow() => setState(() => _isFollowing = !_isFollowing);
+/// Main menu screen listing all assignments.
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 3,
-      margin: const EdgeInsets.all(16),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            CircleAvatar(
-              radius: 48,
-              backgroundImage: AssetImage(widget.imagePath),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              widget.name,
-              style: Theme.of(context)
-                  .textTheme
-                  .titleLarge
-                  ?.copyWith(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              widget.description,
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 20),
-            FilledButton(
-              onPressed: _toggleFollow,
-              child: Text(_isFollowing ? 'Following' : 'Follow'),
-            ),
-          ],
-        ),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Flutter Assignments')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const ProfileCardScreen()),
+              );
+            },
+            child: const Text('Assignment 1 - Profile Card'),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const Assignment2HomeScreen()),
+              );
+            },
+            child: const Text('Assignment 2 - Data Passing'),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const LoginScreen()),
+              );
+            },
+            child: const Text('Assignment 3 - Login Form'),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- refactor Assignment 1 profile card into `lib/assignment1/`
- create Assignment 3 login form with basic validation
- simplify `main.dart` as a navigation hub between all assignments

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7aafaa8c8320a243ba41fccb5a2a