### PR TITLE
Add responsive grid assignment

### DIFF
--- a/lib/assignment6/responsive_grid_screen.dart
+++ b/lib/assignment6/responsive_grid_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+/// Assignment 6 - Displays a responsive grid that adapts to orientation.
+class ResponsiveGridScreen extends StatelessWidget {
+  const ResponsiveGridScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Assignment 6 - Grid')),
+      body: OrientationBuilder(
+        builder: (context, orientation) {
+          final width = MediaQuery.of(context).size.width;
+          final crossAxisCount = orientation == Orientation.portrait
+              ? (width ~/ 200).clamp(2, 3)
+              : (width ~/ 200).clamp(3, 6);
+          return GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+              childAspectRatio: 3 / 4,
+            ),
+            itemCount: _items.length,
+            itemBuilder: (context, index) => _GridItem(_items[index]),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _GridItem extends StatelessWidget {
+  const _GridItem(this.data);
+
+  final _GridItemData data;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: data.color,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black26,
+            blurRadius: 4,
+            offset: Offset(2, 2),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(data.icon, size: 40, color: Colors.white),
+          const SizedBox(height: 12),
+          Text(
+            data.title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            data.description,
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GridItemData {
+  const _GridItemData(this.icon, this.title, this.description, this.color);
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Color color;
+}
+
+const List<_GridItemData> _items = [
+  _GridItemData(Icons.phone, 'Phone', 'Make calls', Colors.blue),
+  _GridItemData(Icons.message, 'Messages', 'Chat with friends', Colors.deepPurple),
+  _GridItemData(Icons.map, 'Maps', 'Find locations', Colors.teal),
+  _GridItemData(Icons.camera_alt, 'Camera', 'Take photos', Colors.indigo),
+  _GridItemData(Icons.music_note, 'Music', 'Listen to songs', Colors.pink),
+  _GridItemData(Icons.shopping_cart, 'Shop', 'Buy products', Colors.orange),
+  _GridItemData(Icons.calendar_today, 'Calendar', 'Plan events', Colors.green),
+  _GridItemData(Icons.settings, 'Settings', 'Configure app', Colors.red),
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'assignment2/home_screen.dart';
 import 'assignment3/login_screen.dart';
 import 'assignment4/todo_list_screen.dart';
 import 'assignment5/user_list_screen.dart';
+import 'assignment6/responsive_grid_screen.dart';
 
 void main() => runApp(const AssignmentsApp());
 
@@ -84,6 +85,16 @@ class HomeScreen extends StatelessWidget {
               );
             },
             child: const Text('Assignment 5 - Users'),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const ResponsiveGridScreen()),
+              );
+            },
+            child: const Text('Assignment 6 - Responsive Grid'),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- implement Assignment 6 with a responsive grid UI
- add navigation to the new screen in the main menu

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bbbd1a1c8320b8dc8ee9e614c2e4