### PR TITLE
Add provider todo tests

### DIFF
--- a/test/todo_list_screen_test.dart
+++ b/test/todo_list_screen_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_assignments/assignment7/todo_list_screen.dart';
+
+void main() {
+  group('TodoListProviderScreen widget', () {
+    testWidgets('adding a task shows it in the list', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: TodoListProviderScreen()));
+
+      await tester.enterText(find.byType(TextField), 'Buy milk');
+      await tester.tap(find.text('Add'));
+      await tester.pump();
+
+      expect(find.text('Buy milk'), findsOneWidget);
+    });
+
+    testWidgets('tapping checkbox toggles completion', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: TodoListProviderScreen()));
+
+      await tester.enterText(find.byType(TextField), 'Task');
+      await tester.tap(find.text('Add'));
+      await tester.pump();
+
+      final checkbox = find.byType(Checkbox).first;
+      expect(tester.widget<Checkbox>(checkbox).value, isFalse);
+
+      await tester.tap(checkbox);
+      await tester.pump();
+
+      expect(tester.widget<Checkbox>(checkbox).value, isTrue);
+    });
+
+    testWidgets('delete icon removes the task', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: TodoListProviderScreen()));
+
+      await tester.enterText(find.byType(TextField), 'Task');
+      await tester.tap(find.text('Add'));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.delete).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Task'), findsNothing);
+    });
+  });
+}

--- a/test/todo_provider_test.dart
+++ b/test/todo_provider_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_assignments/assignment7/models/todo.dart';
+import 'package:flutter_assignments/assignment7/providers/todo_provider.dart';
+
+void main() {
+  group('Todo', () {
+    test('defaults to not completed', () {
+      final todo = Todo(title: 'task');
+      expect(todo.title, 'task');
+      expect(todo.isCompleted, isFalse);
+    });
+  });
+
+  group('TodoProvider', () {
+    late TodoProvider provider;
+
+    setUp(() {
+      provider = TodoProvider();
+    });
+
+    test('add inserts a todo', () {
+      provider.add('one');
+      expect(provider.todos, hasLength(1));
+      expect(provider.todos.first.title, 'one');
+    });
+
+    test('toggle switches completion state', () {
+      provider.add('task');
+      expect(provider.todos.first.isCompleted, isFalse);
+
+      provider.toggle(0);
+      expect(provider.todos.first.isCompleted, isTrue);
+
+      provider.toggle(0);
+      expect(provider.todos.first.isCompleted, isFalse);
+    });
+
+    test('remove deletes the todo', () {
+      provider.add('task');
+      provider.remove(0);
+      expect(provider.todos, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for Todo model and provider logic
- add widget tests for the provider-driven to-do list screen

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863bdd1d7dc8320bcac00108e5cb267