### PR TITLE
Implement DailyWellness basic features

### DIFF
--- a/lib/dailywellness/models/activity.dart
+++ b/lib/dailywellness/models/activity.dart
@@ -1,0 +1,6 @@
+class Activity {
+  Activity({required this.name, this.notes});
+
+  final String name;
+  final String? notes;
+}

--- a/lib/dailywellness/providers/activity_provider.dart
+++ b/lib/dailywellness/providers/activity_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/activity.dart';
+
+class ActivityProvider extends ChangeNotifier {
+  final List<Activity> _activities = [
+    Activity(name: 'Drink water'),
+    Activity(name: 'Meditate'),
+    Activity(name: 'Walk'),
+  ];
+
+  List<Activity> get activities => List.unmodifiable(_activities);
+
+  void add(String name, {String? notes}) {
+    _activities.add(Activity(name: name, notes: notes));
+    notifyListeners();
+  }
+}

--- a/lib/dailywellness/screens/add_activity_screen.dart
+++ b/lib/dailywellness/screens/add_activity_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/activity_provider.dart';
+
+class AddActivityScreen extends StatefulWidget {
+  const AddActivityScreen({super.key});
+
+  @override
+  State<AddActivityScreen> createState() => _AddActivityScreenState();
+}
+
+class _AddActivityScreenState extends State<AddActivityScreen> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _notesController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    if (_formKey.currentState!.validate()) {
+      context.read<ActivityProvider>().add(
+            _nameController.text.trim(),
+            notes: _notesController.text.trim().isEmpty
+                ? null
+                : _notesController.text.trim(),
+          );
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Activity')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Activity Name'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Activity name is required';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _notesController,
+                decoration: const InputDecoration(labelText: 'Notes'),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _save,
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/dailywellness/screens/dashboard_screen.dart
+++ b/lib/dailywellness/screens/dashboard_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/activity_provider.dart';
+import '../services/quote_service.dart';
+import 'add_activity_screen.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key, required this.userEmail});
+
+  final String userEmail;
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  String? _quote;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadQuote();
+  }
+
+  Future<void> _loadQuote() async {
+    try {
+      _quote = await QuoteService().fetchQuote();
+    } catch (_) {
+      _quote = 'Failed to load quote';
+    }
+    if (mounted) {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final activities = context.watch<ActivityProvider>().activities;
+    final now = DateTime.now();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Hello, ${widget.userEmail}',
+                style: Theme.of(context).textTheme.headlineSmall),
+            Text('${now.toLocal()}'),
+            const SizedBox(height: 16),
+            _loading
+                ? const CircularProgressIndicator()
+                : Text(_quote ?? ''),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: activities.length,
+                itemBuilder: (context, index) {
+                  final act = activities[index];
+                  return ListTile(
+                    title: Text(act.name),
+                    subtitle: act.notes != null ? Text(act.notes!) : null,
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const AddActivityScreen()),
+        ),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/dailywellness/screens/login_screen.dart
+++ b/lib/dailywellness/screens/login_screen.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/activity_provider.dart';
+import 'dashboard_screen.dart';
+
+/// Screen implementing a simple login form with validation.
+class DWLoginScreen extends StatefulWidget {
+  const DWLoginScreen({super.key});
+
+  @override
+  State<DWLoginScreen> createState() => _DWLoginScreenState();
+}
+
+class _DWLoginScreenState extends State<DWLoginScreen> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ChangeNotifierProvider(
+            create: (_) => ActivityProvider(),
+            child: DashboardScreen(userEmail: _emailController.text),
+          ),
+        ),
+      );
+    }
+  }
+  String? _validateEmail(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Email is required';
+    }
+    final emailRegex = RegExp(r'^\\S+@\\S+\\.\\S+$');
+    if (!emailRegex.hasMatch(value)) {
+      return 'Enter a valid email';
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Password is required';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DailyWellness Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                keyboardType: TextInputType.emailAddress,
+                validator: _validateEmail,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: _validatePassword,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Login'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/dailywellness/services/quote_service.dart
+++ b/lib/dailywellness/services/quote_service.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class QuoteService {
+  Future<String> fetchQuote() async {
+    try {
+      final response = await http.get(Uri.parse('https://favqs.com/api/qotd'));
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return data['quote']['body'] as String;
+      }
+      throw Exception('Failed to load quote');
+    } catch (_) {
+      rethrow;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -107,6 +107,16 @@ class HomeScreen extends StatelessWidget {
               );
             },
             child: const Text('Assignment 7 - To-Do with Provider'),
+            
+          const SizedBox(height: 12),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const DWLoginScreen()),
+              );
+            },
+            child: const Text('DailyWellness App'),
           ),
         ],
       ),

--- a/test/activity_provider_test.dart
+++ b/test/activity_provider_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_assignments/dailywellness/providers/activity_provider.dart';
+
+void main() {
+  group('ActivityProvider', () {
+    late ActivityProvider provider;
+
+    setUp(() {
+      provider = ActivityProvider();
+    });
+
+    test('initial activities length', () {
+      expect(provider.activities.length, 3);
+    });
+
+    test('add adds an activity', () {
+      provider.add('Jogging');
+      expect(provider.activities.last.name, 'Jogging');
+    });
+  });
+}

--- a/test/add_activity_form_test.dart
+++ b/test/add_activity_form_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_assignments/dailywellness/screens/add_activity_screen.dart';
+import 'package:flutter_assignments/dailywellness/providers/activity_provider.dart';
+
+void main() {
+  testWidgets('shows error when name is empty', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => ActivityProvider(),
+        child: const MaterialApp(home: AddActivityScreen()),
+      ),
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(find.text('Activity name is required'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- create DailyWellness app with activity model and provider
- add login, dashboard, and add-activity screens
- hook DailyWellness launch into main menu
- add tests for ActivityProvider and activity form

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6370e5788320ace5effa90cf89a9